### PR TITLE
Fix security hub checks

### DIFF
--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11.1-alpine
 
 WORKDIR /usr/src/app
+VOLUME /usr/src/app
 
 COPY requirements.txt ./
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -219,7 +219,7 @@ These checks may show the detection of CRITICAL and HIGH severity by Security Hu
 - CodeBuild's priviledge mode should be disable except when docker image build is required.
 - In this template, priviledge mode is enable because pipeline build a docker image.
 - Please check your enviornment and requirements and fix this configuration.
-  - If you want to fix template's configuration, [please change the priviledge parameter of CodePipeline`s construct](lib/constructs/codepipeline/codepipeline.ts#L65) to `false`
+  - If you want to fix template's configuration, [please change the priviledge parameter of CodePipeline's construct](lib/constructs/codepipeline/codepipeline.ts#L65) to `false`
   - Refer:[interface BuildEnvironment - privileged](https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-codebuild.BuildEnvironment.html#privileged)
 
 ## Path to production

--- a/infra/README.md
+++ b/infra/README.md
@@ -191,9 +191,9 @@ For specific usage, see [Manage application security and compliance with the AWS
 When Security Hub is enable, two policies will be enable by default.
 
 - [AWS Foundational Security Best Practices (FSBP) standard](https://docs.aws.amazon.com/securityhub/latest/userguide/fsbp-standard.html)
-- [Center for Internet Security (CIS) AWS Foundations Benchmark v1.2.0 and v1.4.0](https://docs.aws.amazon.com/ja_jp/securityhub/latest/userguide/cis-aws-foundations-benchmark.html)
+- [Center for Internet Security (CIS) AWS Foundations Benchmark v1.2.0](https://docs.aws.amazon.com/ja_jp/securityhub/latest/userguide/cis-aws-foundations-benchmark.html)
 
-These checks shows the detection of CRITICAL and HIGH severity by Security Hub.
+These checks may show the detection of CRITICAL and HIGH severity by Security Hub.
 
 ### Enable MFA for the root user
 
@@ -203,7 +203,7 @@ These checks shows the detection of CRITICAL and HIGH severity by Security Hub.
 - [[CIS.1.14] Ensure hardware MFA is enabled for the "root" account](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.14)
 - [[IAM.6] Hardware MFA should be enabled for the root user](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-iam-6)
 
-#### How to solve
+#### How to fix
 
 - Access the management console as root user and follow below document.
   - [Enable a hardware TOTP token for the AWS account root user (console)](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_physical.html#enable-hw-mfa-for-root)
@@ -214,7 +214,7 @@ These checks shows the detection of CRITICAL and HIGH severity by Security Hub.
 
 - [[CodeBuild.5] CodeBuild project environments should not have privileged mode enabled](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-codebuild-5)
 
-#### How to solve
+#### How to fix
 
 - CodeBuild's priviledge mode should be disable except when docker image build is required.
 - In this template, priviledge mode is enable because pipeline build a docker image.

--- a/infra/README.md
+++ b/infra/README.md
@@ -186,6 +186,42 @@ The rules that have been excluded are described together at the bottom of the so
 
 For specific usage, see [Manage application security and compliance with the AWS Cloud Development Kit and cdk-nag](https://aws.amazon.com/jp/blogs/news/manage-application-security-and-compliance-with-the-aws-cloud-development-kit-and-cdk-nag/).
 
+## How to solve the checks of Security Hub
+
+When Security Hub is enable, two policies will be enable by default.
+
+- [AWS Foundational Security Best Practices (FSBP) standard](https://docs.aws.amazon.com/securityhub/latest/userguide/fsbp-standard.html)
+- [Center for Internet Security (CIS) AWS Foundations Benchmark v1.2.0 and v1.4.0](https://docs.aws.amazon.com/ja_jp/securityhub/latest/userguide/cis-aws-foundations-benchmark.html)
+
+These checks shows the detection of CRITICAL and HIGH severity by Security Hub.
+
+### Enable MFA for the root user
+
+#### Checks
+
+- [[CIS.1.13] Ensure MFA is enabled for the "root" account](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.13)
+- [[CIS.1.14] Ensure hardware MFA is enabled for the "root" account](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.14)
+- [[IAM.6] Hardware MFA should be enabled for the root user](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-iam-6)
+
+#### How to solve
+
+- Access the management console as root user and follow below document.
+  - [Enable a hardware TOTP token for the AWS account root user (console)](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_physical.html#enable-hw-mfa-for-root)
+
+### Disable CodeBuild's privileged mode
+
+#### Checks
+
+- [[CodeBuild.5] CodeBuild project environments should not have privileged mode enabled](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-codebuild-5)
+
+#### How to solve
+
+- CodeBuild's priviledge mode should be disable except when docker image build is required.
+- In this template, priviledge mode is enable because pipeline build a docker image.
+- Please check your enviornment and requirements and fix this configuration.
+  - If you want to fix template's configuration, [please change the priviledge parameter of CodePipeline`s construct](lib/constructs/codepipeline/codepipeline.ts#L65) to `false`
+  - Refer:[interface BuildEnvironment - privileged](https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-codebuild.BuildEnvironment.html#privileged)
+
 ## Path to production
 
 ### Security updates to EC2

--- a/infra/README_ja.md
+++ b/infra/README_ja.md
@@ -181,7 +181,7 @@ $ npm run list -- --{alias}
 Security Hub を有効にした場合、デフォルトで有効になる基準は以下の 2 つです。
 
 - [AWS Foundational Security Best Practices (FSBP) standard](https://docs.aws.amazon.com/ja_jp/securityhub/latest/userguide/fsbp-standard.html)
-- [Center for Internet Security (CIS) AWS Foundations Benchmark v1.2.0 and v1.4.0](https://docs.aws.amazon.com/ja_jp/securityhub/latest/userguide/cis-aws-foundations-benchmark.html)
+- [Center for Internet Security (CIS) AWS Foundations Benchmark v1.2.0](https://docs.aws.amazon.com/ja_jp/securityhub/latest/userguide/cis-aws-foundations-benchmark.html)
 
 これらのチェックが行われると、ベンチマークレポートで重要度が CRITICAL あるいは HIGH のレベルでレポートされる検出項目があります。
 これらに対しては、別途対応が必要になります。

--- a/infra/README_ja.md
+++ b/infra/README_ja.md
@@ -19,7 +19,6 @@ $ aws configure --profile {プロファイル名}
 IAM ユーザ作成時に表示される、アクセスキーとシークレットキー、デフォルトのリージョンが確認されます。
 詳しくは[aws configure を使用したクイック設定 - プロファイル](https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-profiles)をご参照ください。
 
-
 ### 2. stages.js の書き換え
 
 本テンプレートは、タスクランナーの[gulp](https://gulpjs.com/)を利用してデプロイを行います。
@@ -74,7 +73,7 @@ $ npm run deploy -- --{alias}
 
 デプロイ後、ターミナル上に以下に示すようなコマンドが出力されますので、コピーして実行してください。
 生成された EC2 インスタンス 用の Keypair がそれぞれ取得できます。
-コンソール接続する場合や Fleet Manager から RDP 接続する際には、Keypair の取得を行ってください。（コマンド実行時にはProfileの指定をお願いします）
+コンソール接続する場合や Fleet Manager から RDP 接続する際には、Keypair の取得を行ってください。（コマンド実行時には Profile の指定をお願いします）
 
 ```
 // regionがap-northeast-1のWindowsインスタンスの場合
@@ -176,6 +175,41 @@ $ npm run list -- --{alias}
 必要に応じて例外化の追加・削除を実施ください。
 
 具体的な使い方については、[AWS Cloud Development Kit と cdk-nag でアプリケーションのセキュリティとコンプライアンスを管理する](https://aws.amazon.com/jp/blogs/news/manage-application-security-and-compliance-with-the-aws-cloud-development-kit-and-cdk-nag/)、にて解説していますので、ご参照ください。
+
+## Security Hub のチェック結果
+
+Security Hub を有効にした場合、デフォルトで有効になる基準は以下の 2 つです。
+
+- [AWS Foundational Security Best Practices (FSBP) standard](https://docs.aws.amazon.com/ja_jp/securityhub/latest/userguide/fsbp-standard.html)
+- [Center for Internet Security (CIS) AWS Foundations Benchmark v1.2.0 and v1.4.0](https://docs.aws.amazon.com/ja_jp/securityhub/latest/userguide/cis-aws-foundations-benchmark.html)
+
+これらのチェックが行われると、ベンチマークレポートで重要度が CRITICAL あるいは HIGH のレベルでレポートされる検出項目があります。
+これらに対しては、別途対応が必要になります。
+
+### ルートユーザへの MFA の適用
+
+#### 検出項目
+
+- [[CIS.1.13] Ensure MFA is enabled for the "root" account](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.13)
+- [[CIS.1.14] Ensure hardware MFA is enabled for the "root" account](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.14)
+- [[IAM.6] Hardware MFA should be enabled for the root user](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-iam-6)
+
+#### 修復方法
+
+- ルートユーザで AWS にログインし、以下のドキュメントに沿って MFA を有効化してください。
+  - [AWS アカウント のルートユーザー (コンソール) 用にハードウェア TOTP トークンを有効にします](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_physical.html#enable-hw-mfa-for-root)
+
+### CodeBuild の特権モードの無効化
+
+#### 検出項目
+
+- [[CodeBuild.5] CodeBuild project environments should not have privileged mode enabled](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-codebuild-5)
+
+#### 修復方法
+
+- CodeBuild では、Docker イメージをビルドする必要がある場合を除き、特権モードは無効化してください。本テンプレートでは、Docker イメージのビルドを行っているため、有効化していますが、実際に利用される場合は、ご自身の環境に合った設定にご変更ください。
+  - テンプレートだけの対応であれば、[CodePipeline のコンストラクト内の特権モードの設定](lib/constructs/codepipeline/codepipeline.ts#L65)を`false`に変更してください。
+  - ご参考：[interface BuildEnvironment - privileged](https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-codebuild.BuildEnvironment.html#privileged)
 
 ## 本番利用時の考慮点
 

--- a/infra/docker/nginx/Dockerfile
+++ b/infra/docker/nginx/Dockerfile
@@ -1,4 +1,9 @@
 FROM nginx
 
+VOLUME /var/cache/nginx
+VOLUME /var/run
+VOLUME /etc/nginx/conf.d
+VOLUME /usr/share/nginx/html
+
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY static-content /usr/share/nginx/html

--- a/infra/lib/constructs/ec2/bastion.ts
+++ b/infra/lib/constructs/ec2/bastion.ts
@@ -88,6 +88,7 @@ export class Bastion extends Construct {
           }),
         },
       ],
+      requireImdsv2: true,
     });
     this.bastionInstance = bastionInstance;
 

--- a/infra/lib/constructs/ecs/ecs-app-service.ts
+++ b/infra/lib/constructs/ecs/ecs-app-service.ts
@@ -102,6 +102,7 @@ export class EcsAppService extends Construct {
         streamPrefix: `${id}-`,
         logGroup: logGroupForCluster,
       }),
+      readonlyRootFilesystem: true,
     });
 
     this.ecsContainer.addPortMappings({

--- a/infra/lib/constructs/ecs/ecs-job.ts
+++ b/infra/lib/constructs/ecs/ecs-job.ts
@@ -120,6 +120,7 @@ export class EcsJob extends Construct {
         streamPrefix: `${id.toLowerCase()}-`,
         logGroup: logGroupForFargate,
       }),
+      readonlyRootFilesystem: true,
     });
 
     this.task = this.ecsJob('InvokeJob', this.jobId, 'RUNTASK', container, taskDefinition);

--- a/webapp-java/Dockerfile
+++ b/webapp-java/Dockerfile
@@ -1,16 +1,23 @@
 # For build
 FROM amazoncorretto:17-alpine AS build
+RUN apk update && apk add curl 
+
 ENV HOME=/home/app
 RUN mkdir -p $HOME
 WORKDIR $HOME
 ADD . $HOME
+RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o $HOME/root.pem
 RUN ./gradlew build
 
 # For app
 FROM amazoncorretto:17-alpine
-RUN apk update && apk add curl 
-RUN curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /tmp/root.pem
+
+VOLUME /home/spring
+VOLUME /tmp
+
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
+
 COPY --from=build /home/app/build/libs/webapp-java-0.0.1-SNAPSHOT.jar sampleapp.jar
+COPY --from=build /home/app/root.pem /tmp/root.pem
 CMD ["java","-jar","/sampleapp.jar"]

--- a/webapp-java/buildspec.yaml
+++ b/webapp-java/buildspec.yaml
@@ -12,7 +12,6 @@ phases:
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:
     commands:
-      - ./gradlew build
       - docker build . -t $REPOSITORY_URI:latest
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:


### PR DESCRIPTION
*Description of changes:*

This pull request is to pass checks of the Critical and High severity that given by _**AWS Foundational Security Best Practices v1.0.0**_ and _**CIS AWS Foundations Benchmark v1.2.0**_ on Security Hub

**Passed**
  - EC2 instances should use Instance Metadata Service Version 2 (IMDSv2)
  - ECS containers should be limited to read-only access to root filesystems

**Documented**
  - 1.14 Ensure hardware MFA is enabled for the root user
  - IAM.6 Hardware MFA should be enabled for the root user
  - 1.13 Ensure MFA is enabled for the root user
  - CodeBuild.5 CodeBuild project environments should not have privileged mode enabled

Checks of documented are existing because of this configuration of required or depends on each users.
So, added the note to deal with these checks.