### PR TITLE
Enable export cloudwatchlogs

### DIFF
--- a/infra/lib/constructs/aurora/aurora.ts
+++ b/infra/lib/constructs/aurora/aurora.ts
@@ -71,6 +71,7 @@ export class Aurora extends Construct {
         parameters: {
           'rds.force_ssl': '1',
         },
+        cloudwatchLogsExports: ['postgresql'],
       });
 
       if (props.enabledProxy && this.aurora.secret) {

--- a/webapp-java/src/main/java/com/example/sampleapp/webapp/controller/SampleAppController.java
+++ b/webapp-java/src/main/java/com/example/sampleapp/webapp/controller/SampleAppController.java
@@ -14,7 +14,6 @@ import com.example.sampleapp.webapp.domain.SampleAppService;
 
 @Controller
 public class SampleAppController {
-
 	private final SampleAppService service;
 	public SampleAppService sampleAppService;
 
@@ -22,7 +21,7 @@ public class SampleAppController {
 		this.service = service;
 	}
 
-	@RequestMapping(value = {"/sampleapp/list", "/"})
+	@RequestMapping(value = { "/sampleapp/list", "/" })
 	@GetMapping
 	public String sampleAppList(Model model) {
 
@@ -40,8 +39,6 @@ public class SampleAppController {
 		return "sampleappform";
 	}
 
-
-
 	@RequestMapping("/sampleapp/form/update")
 	@PostMapping
 	public String sampleAppListUpdate(@Validated @ModelAttribute SampleAppListDto sampleappformlist,
@@ -49,8 +46,7 @@ public class SampleAppController {
 
 		service.updateAll(sampleappformlist);
 		model.addAttribute("sampleapplist", service.listAll());
-		return "redirect:/sampleapp/list";
+		return "forward:/";
 	}
-
 
 }


### PR DESCRIPTION
**Issues:**
- This template didn't export DB logs to CloudWatch Logs and didn't follow non-functional requirement of local government's system.
- Java sample app had bag that could not return response after updating record.

**This pull request is to fix below:**
- Enable export DB logs to CloudWatch Logs in aurora construct.
- Change the way to return response from 'Redirect' to 'Forward'. Because Spring boot uses HTTP in default when apps use Redirect.